### PR TITLE
ci: add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   ci:


### PR DESCRIPTION
Add `workflow_dispatch` trigger to CI workflow, enabling manual re-runs from the Actions tab.