### PR TITLE
fix(lint): ignore coverage directory in ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", "coverage/**"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],


### PR DESCRIPTION
Add `coverage/**` to ESLint ignores to prevent scanning generated coverage report files that contain unused eslint-disable directives.