### PR TITLE
chore(deps): bump eslint-plugin-react-refresh to 0.5.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
         "@vitest/coverage-v8": "4.1.8",
         "eslint": "10.5.0",
         "eslint-plugin-react-hooks": "7.1.1",
-        "eslint-plugin-react-refresh": "0.5.2",
+        "eslint-plugin-react-refresh": "0.5.3",
         "globals": "17.6.0",
         "husky": "^9.1.7",
         "jsdom": "29.1.1",
@@ -582,7 +582,7 @@
 
     "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.1.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0" } }, "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="],
 
-    "eslint-plugin-react-refresh": ["eslint-plugin-react-refresh@0.5.2", "", { "peerDependencies": { "eslint": "^9 || ^10" } }, "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA=="],
+    "eslint-plugin-react-refresh": ["eslint-plugin-react-refresh@0.5.3", "", { "peerDependencies": { "eslint": "^9 || ^10" } }, "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA=="],
 
     "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@vitest/coverage-v8": "4.1.8",
     "eslint": "10.5.0",
     "eslint-plugin-react-hooks": "7.1.1",
-    "eslint-plugin-react-refresh": "0.5.2",
+    "eslint-plugin-react-refresh": "0.5.3",
     "globals": "17.6.0",
     "husky": "^9.1.7",
     "jsdom": "29.1.1",


### PR DESCRIPTION
## Summary

Patch bump `eslint-plugin-react-refresh` 0.5.2 → 0.5.3 (devDependency).

## Validation

- ✅ `bun install --frozen-lockfile`
- ✅ `bun run lint` (max-warnings=0)
- ✅ `bun run typecheck`
- ✅ `bun run build`
- ✅ `bun run test` — 25 files / 116 tests passed
- ✅ `bun audit` — no vulnerabilities
- Lock file resolves to a single `eslint-plugin-react-refresh@0.5.3`; peer remains compatible with `eslint@10.5.0`; no extra transitive surface.

Closes #73