### PR TITLE
chore(deps): bump lucide-react 1.20.0 & react-router 7.18.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "cmdk": "^1.1.1",
         "i18next": "26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
-        "lucide-react": "1.18.0",
+        "lucide-react": "1.20.0",
         "postcss": "8.5.15",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -722,7 +722,7 @@
 
     "lru-cache": ["lru-cache@11.4.0", "", {}, "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA=="],
 
-    "lucide-react": ["lucide-react@1.18.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA=="],
+    "lucide-react": ["lucide-react@1.20.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-i18next": "17.0.8",
-        "react-router": "7.17.0",
+        "react-router": "7.18.0",
         "recharts": "^3.8.1",
         "sonner": "2.0.7",
         "tailwind-merge": "3.6.0",
@@ -788,7 +788,7 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
-    "react-router": ["react-router@7.17.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ=="],
+    "react-router": ["react-router@7.18.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "cmdk": "^1.1.1",
     "i18next": "26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
-    "lucide-react": "1.18.0",
+    "lucide-react": "1.20.0",
     "postcss": "8.5.15",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-i18next": "17.0.8",
-    "react-router": "7.17.0",
+    "react-router": "7.18.0",
     "recharts": "^3.8.1",
     "sonner": "2.0.7",
     "tailwind-merge": "3.6.0"


### PR DESCRIPTION
## Summary

Batch dependency upgrade reviewed by Reviewer-04.

- bump `lucide-react` 1.18.0 → 1.20.0
- bump `react-router` 7.17.0 → 7.18.0

## Linked issues

Closes #103
Closes #104

## Notes

Branch was reviewed and approved by Reviewer-04; commit contents are unchanged. Handed off for push/PR after the original author run was stopped by the idle watchdog.