### PR TITLE
chore(deps): upgrade dependencies (batch 2026-06-19)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,12 +34,12 @@
         "cmdk": "^1.1.1",
         "i18next": "26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",
-        "lucide-react": "1.20.0",
+        "lucide-react": "1.21.0",
         "postcss": "8.5.15",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-i18next": "17.0.8",
-        "react-router": "8.0.0",
+        "react-router": "8.0.1",
         "recharts": "^3.8.1",
         "sonner": "2.0.7",
         "tailwind-merge": "3.6.0",
@@ -68,6 +68,9 @@
         "vitest": "4.1.9",
       },
     },
+  },
+  "overrides": {
+    "undici": "^7.28.0",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -722,7 +725,7 @@
 
     "lru-cache": ["lru-cache@11.4.0", "", {}, "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA=="],
 
-    "lucide-react": ["lucide-react@1.20.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ=="],
+    "lucide-react": ["lucide-react@1.21.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
@@ -788,7 +791,7 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
-    "react-router": ["react-router@8.0.0", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-AyS7LUn9M3g2/IBJDJNpWqElaQjPVBHGgMsdLGee6B2JLwP9STSpRwN8N4SauOeFTb0X5ZN0wxa1Iek78jF8Iw=="],
+    "react-router": ["react-router@8.0.1", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-5EL/fANovVUhRK50NLS8RYfX0BxrimoKsHWUPPy8v5UEl8i6vzF7e4POo3u+AhPItDwccUAJjMfIOmydxBJmQw=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
@@ -868,7 +871,7 @@
 
     "typescript-eslint": ["typescript-eslint@8.61.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.61.1", "@typescript-eslint/parser": "8.61.1", "@typescript-eslint/typescript-estree": "8.61.1", "@typescript-eslint/utils": "8.61.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw=="],
 
-    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
     "cmdk": "^1.1.1",
     "i18next": "26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
-    "lucide-react": "1.20.0",
+    "lucide-react": "1.21.0",
     "postcss": "8.5.15",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-i18next": "17.0.8",
-    "react-router": "8.0.0",
+    "react-router": "8.0.1",
     "recharts": "^3.8.1",
     "sonner": "2.0.7",
     "tailwind-merge": "3.6.0"
@@ -78,6 +78,9 @@
     "typescript-eslint": "8.61.1",
     "vite": "8.0.16",
     "vitest": "4.1.9"
+  },
+  "overrides": {
+    "undici": "^7.28.0"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
## Summary

Batch dependency upgrade tracked in STU-936.

| Package | Old | New | Notes |
|---|---|---|---|
| `lucide-react` | 1.20.0 | 1.21.0 | direct dep |
| `react-router` | 8.0.0 | 8.0.1 | direct dep |
| `undici` (transitive via `jsdom`) | 7.25.0 | 7.28.0 | pinned via `package.json` `overrides`; patches GHSA-pr7r-676h-xcf6 and GHSA-vmh5-mc38-953g. jsdom's own `^7.25.0` range is unchanged — only the lower bound is bumped. No new root-level runtime dependency on undici. |

Closes #108, #109, #110.

## Verification (local)

- `bun install` clean
- `bunx eslint . --max-warnings=0` pass
- `bunx tsc --noEmit` pass
- `bunx vitest run` 25 files / 116 tests pass
- `bun run build` pass (pre-existing chunk size warning only)

## Test plan

- [ ] CI: lint, typecheck, unit tests, build
- [ ] CI: OSV / dependency scan no longer flags GHSA-pr7r-676h-xcf6 or GHSA-vmh5-mc38-953g