### PR TITLE
chore(deps): bump @types/node and i18next (batch 2026-06-25)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,7 @@
         "@tailwindcss/vite": "4.3.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@types/node": "26.0.0",
+        "@types/node": "26.0.1",
         "@types/react": "19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react-swc": "^4.3.0",
@@ -431,7 +431,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
+    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "i18next": "26.3.1",
+        "i18next": "26.3.2",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "1.21.0",
         "postcss": "8.5.15",
@@ -649,7 +649,7 @@
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
-    "i18next": ["i18next@26.3.1", "", { "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ=="],
+    "i18next": ["i18next@26.3.2", "", { "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-QQkXAM1sPDHqhxMQuBeHVMUn6mJchF+wdpOoQerciLAFqO3ZYdxO0EUbeEhruyutnNwpUQIITDVzLjwnNL0T1w=="],
 
     "i18next-browser-languagedetector": ["i18next-browser-languagedetector@8.2.1", "", { "dependencies": { "@babel/runtime": "^7.23.2" } }, "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "i18next": "26.3.1",
+    "i18next": "26.3.2",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "1.21.0",
     "postcss": "8.5.15",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@tailwindcss/vite": "4.3.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "26.0.0",
+    "@types/node": "26.0.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.3.0",


### PR DESCRIPTION
## Summary

- Bump `@types/node` (devDependency) `26.0.0` → `26.0.1` (closes #122)
- Bump `i18next` (dependency) `26.3.1` → `26.3.2` (closes #123)

Each commit is atomic and only touches `package.json` + `bun.lock` for a single package, so #122 / #123 close cleanly via per-commit `Closes` trailers when merged.

## Verification

Clean reinstall (`rm -rf node_modules .next` then `bun add`) before each bump, then:

- `bun run typecheck` ✅
- `bun run lint` (`eslint --max-warnings=0 .`) ✅
- `bun run test` ✅ 25 files / 116 tests
- `bun run build` ✅ vite 8.1.0
- husky pre-commit hook (vitest + gitleaks) passed on both commits
- Independent re-verify by Reviewer-02 (`bun install --frozen-lockfile`, `git diff --check`, typecheck/lint/test/build) — approved

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test`
- [x] `bun run build`
