### PR TITLE
chore(deps): bump i18next to 26.3.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "i18next": "26.3.2",
+        "i18next": "26.3.3",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "1.21.0",
         "postcss": "8.5.15",
@@ -649,7 +649,7 @@
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
-    "i18next": ["i18next@26.3.2", "", { "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-QQkXAM1sPDHqhxMQuBeHVMUn6mJchF+wdpOoQerciLAFqO3ZYdxO0EUbeEhruyutnNwpUQIITDVzLjwnNL0T1w=="],
+    "i18next": ["i18next@26.3.3", "", { "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-aYVegyBdXSO93CMMihvr47jI7GHSOcIahMpJX+qzUXDzW4xDJf2uenIA+45vDU+YhiVdcfsql70AC9RVdMNrHg=="],
 
     "i18next-browser-languagedetector": ["i18next-browser-languagedetector@8.2.1", "", { "dependencies": { "@babel/runtime": "^7.23.2" } }, "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "i18next": "26.3.2",
+    "i18next": "26.3.3",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "1.21.0",
     "postcss": "8.5.15",


### PR DESCRIPTION
## Summary

- Bump `i18next` from `26.3.2` → `26.3.3` (patch).
- Closes nocoo/basalt#126

## Verification

- `bun typecheck` ✅
- `bun run test` → 25 files / 116 tests ✅
- `eslint --max-warnings=0` ✅ (pre-commit)
- gitleaks ✅ (pre-commit)
