### PR TITLE
chore(deps): upgrade dependencies (batch 2026-07-02)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,7 @@
         "@tailwindcss/vite": "4.3.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@types/node": "26.0.1",
+        "@types/node": "26.1.0",
         "@types/react": "19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react-swc": "^4.3.0",
@@ -431,7 +431,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "cmdk": "^1.1.1",
         "i18next": "26.3.4",
         "i18next-browser-languagedetector": "^8.2.1",
-        "lucide-react": "1.22.0",
+        "lucide-react": "1.23.0",
         "postcss": "8.5.16",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -725,7 +725,7 @@
 
     "lru-cache": ["lru-cache@11.4.0", "", {}, "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA=="],
 
-    "lucide-react": ["lucide-react@1.22.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg=="],
+    "lucide-react": ["lucide-react@1.23.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@tailwindcss/vite": "4.3.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "26.0.1",
+    "@types/node": "26.1.0",
     "@types/react": "19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "cmdk": "^1.1.1",
     "i18next": "26.3.4",
     "i18next-browser-languagedetector": "^8.2.1",
-    "lucide-react": "1.22.0",
+    "lucide-react": "1.23.0",
     "postcss": "8.5.16",
     "react": "19.2.7",
     "react-dom": "19.2.7",


### PR DESCRIPTION
## Summary

Batch dependency upgrade for 2026-07-02 (STU-1492).

- `@types/node` 26.0.1 → 26.1.0 (closes #165)
- `lucide-react` 1.22.0 → 1.23.0 (closes #166)

Lockfile diff limited to the two bumped packages; no cascading resolutions.

## Verification

Local pre-push (all green):

- `bun install --frozen-lockfile`
- `bun run lint` — 0 warnings
- `bun run typecheck`
- `bun run build` — 855 modules
- `bun run test` — 25 files / 116 tests
- `osv-scanner scan --lockfile=bun.lock --config=osv-scanner.toml` — No issues found

Reviewer-04 has approved both atomic commits.

## Test plan

- [x] Local lint / typecheck / build / test pass
- [x] OSV gate passes
- [ ] base-ci passes on PR
