### PR TITLE
chore(deps): bump recharts 3.9.1 → 3.9.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,7 @@
         "react-dom": "19.2.7",
         "react-i18next": "17.0.8",
         "react-router": "8.1.0",
-        "recharts": "3.9.1",
+        "recharts": "3.9.2",
         "sonner": "2.0.7",
         "tailwind-merge": "3.6.0",
       },
@@ -795,7 +795,7 @@
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
-    "recharts": ["recharts@3.9.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg=="],
+    "recharts": ["recharts@3.9.2", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-dom": "19.2.7",
     "react-i18next": "17.0.8",
     "react-router": "8.1.0",
-    "recharts": "3.9.1",
+    "recharts": "3.9.2",
     "sonner": "2.0.7",
     "tailwind-merge": "3.6.0"
   },


### PR DESCRIPTION
## Summary
- Patch bump `recharts` from `3.9.1` to `3.9.2`.
- Only `package.json` and `bun.lock` changed.

Closes nocoo/basalt#171

## Verification
- `bunx eslint . --max-warnings=0` ✅
- `bun run typecheck` (`tsc --noEmit`) ✅
- `bunx vitest run` ✅ 25 files / 116 tests
- `bun run build` ✅

## Test plan
- [x] Lint
- [x] Typecheck
- [x] Unit tests
- [x] Production build