### PR TITLE
chore(deps): bump postcss 8.5.17 → 8.5.18

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
         "i18next": "26.3.6",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "1.24.0",
-        "postcss": "8.5.17",
+        "postcss": "8.5.18",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-i18next": "17.0.9",
@@ -769,7 +769,7 @@
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
-    "postcss": ["postcss@8.5.17", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w=="],
+    "postcss": ["postcss@8.5.18", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "i18next": "26.3.6",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "1.24.0",
-    "postcss": "8.5.17",
+    "postcss": "8.5.18",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-i18next": "17.0.9",


### PR DESCRIPTION
Closes #213

Patch bump for postcss.

## Verification

- `bunx tsc --noEmit` ✓
- `bunx eslint . --max-warnings=0` ✓
- `bunx vitest run` — 25 files / 116 tests passed ✓
- `bun run build` ✓