### PR TITLE
chore(deps): lucide-react 1.24.0 → 1.25.0 + release v1.3.2 (STU-1965)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.3.2] - 2026-07-18
+
+### Changed
+
+- **Dependencies (minor bump)**:
+  - `lucide-react` 1.24.0 → 1.25.0
+  Closes basalt#226.
+
 ## [1.3.1] - 2026-07-17
 
 ### Changed

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "cmdk": "^1.1.1",
         "i18next": "26.3.6",
         "i18next-browser-languagedetector": "^8.2.1",
-        "lucide-react": "1.24.0",
+        "lucide-react": "1.25.0",
         "postcss": "8.5.19",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -611,7 +611,7 @@
 
     "lru-cache": ["lru-cache@11.4.0", "", {}, "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA=="],
 
-    "lucide-react": ["lucide-react@1.24.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA=="],
+    "lucide-react": ["lucide-react@1.25.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "basalt",
 	"private": true,
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"type": "module",
 	"packageManager": "bun@1.3.6",
 	"scripts": {
@@ -48,7 +48,7 @@
 		"cmdk": "^1.1.1",
 		"i18next": "26.3.6",
 		"i18next-browser-languagedetector": "^8.2.1",
-		"lucide-react": "1.24.0",
+		"lucide-react": "1.25.0",
 		"postcss": "8.5.19",
 		"react": "19.2.7",
 		"react-dom": "19.2.7",


### PR DESCRIPTION
## Summary

Bumps `lucide-react` from `1.24.0` to `1.25.0` (minor) and releases v1.3.2.

Related: STU-1965
Closes #226

## Changes

- `package.json`: `lucide-react` 1.24.0 → 1.25.0; app version 1.3.1 → 1.3.2
- `bun.lock`: synced
- `CHANGELOG.md`: new `[1.3.2] - 2026-07-18` entry

## Verification

- `bun install --frozen-lockfile` ✅
- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- `bun run test` ✅ (26 files / 118 tests)
